### PR TITLE
Add kv visualizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vs code
+.vscode

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 kivy = "*"
 watchdog = "*"
+plyer = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "00bb5ec24661202a17fd8eb19113b61216d45e190409592ba04ad5d9554814d3"
+            "sha256": "759bf8c46bfcc896fa070ba1df6488e370934d724a4e6e8c39ea854e8a00992b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,11 +18,11 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:36973885b9542e6bd01dea287b2b4b3b21236307c56324fcc3f1160f2d655ed5",
-                "sha256:e232343de1ab72c2aa521b625c80f699e356830fd0e2c620b465b304b17b0516"
+                "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
+                "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2022.9.14"
+            "version": "==2022.9.24"
         },
         "charset-normalizer": {
             "hashes": [
@@ -123,6 +123,14 @@
                 "sha256:ef50f44b96358cf10ac5665f27a4751bb34ef54051c54b93af891f80afe42929"
             ],
             "version": "==0.1.5"
+        },
+        "plyer": {
+            "hashes": [
+                "sha256:8de38b17bc438df36eedeacd546cf05303ab871855af0669fc4e8df51f2adf94",
+                "sha256:d62a1e68622042e6b9367ba429844e989ea7b13035fd1befe66f385aaaba6de1"
+            ],
+            "index": "pypi",
+            "version": "==2.0.0"
         },
         "pygments": {
             "hashes": [

--- a/src/KivyDesigner.kv
+++ b/src/KivyDesigner.kv
@@ -20,7 +20,7 @@ RootWidget:
         FileToolbarGroup:
             size_hint: None, 1
             width: '50dp'
-            on_open_file: root.change_filename(*args)
+            on_open_file: visualizer.open_file(*args)
     BoxLayout: 
         # The main application including everything except toolbar
         BoxLayout:
@@ -32,3 +32,4 @@ RootWidget:
             Label:
                 text: 'Side Toolbar Future Pos.'
         KivyVisualizer:
+            id: visualizer

--- a/src/KivyDesigner.kv
+++ b/src/KivyDesigner.kv
@@ -1,7 +1,7 @@
 #:import ICON_PATH main.ICON_PATH
 #:set menubar_color (0.2, 0.2, 0.2, 1)
 
-BoxLayout:
+RootWidget:
     orientation: 'vertical'
     # This BoxLayout and child layouts create the menubar
     Toolbar: 
@@ -20,6 +20,7 @@ BoxLayout:
         FileToolbarGroup:
             size_hint: None, 1
             width: '50dp'
+            on_open_file: root.change_filename(*args)
     BoxLayout: 
         # The main application including everything except toolbar
         BoxLayout:

--- a/src/KivyDesigner.kv
+++ b/src/KivyDesigner.kv
@@ -1,7 +1,7 @@
 #:import ICON_PATH main.ICON_PATH
 #:set menubar_color (0.2, 0.2, 0.2, 1)
 
-<KivyDesignerRoot>:
+BoxLayout:
     orientation: 'vertical'
     # This BoxLayout and child layouts create the menubar
     BoxLayout: 
@@ -48,4 +48,21 @@
                     height: '24dp'
                     on_release: file_dropdown.select('Open Folder')
     BoxLayout: 
-        # Rest of the application goes here
+        # The main application including everything except toolbar
+        BoxLayout:
+            # Side toolbar. Set to fixed size of 275 dp 
+            # In the future we can allow the user to edit this
+            # by sliding a resize bar
+            size_hint: (None, 1)
+            width: '300dp'
+            Label:
+                text: 'Side Toolbar Future Pos.'
+        BoxLayout:
+            # Kivy Visualizer & File Editor
+            BoxLayout:
+                Label:
+                    background_color: 0.8,0.2,0.2,1
+                    text: 'Editor'
+            BoxLayout:
+                Label: 
+                    text: 'Visualizer'

--- a/src/KivyDesigner.kv
+++ b/src/KivyDesigner.kv
@@ -57,12 +57,4 @@ BoxLayout:
             width: '300dp'
             Label:
                 text: 'Side Toolbar Future Pos.'
-        BoxLayout:
-            # Kivy Visualizer & File Editor
-            BoxLayout:
-                Label:
-                    background_color: 0.8,0.2,0.2,1
-                    text: 'Editor'
-            BoxLayout:
-                Label: 
-                    text: 'Visualizer'
+        KivyVisualizer:

--- a/src/KivyDesigner.kv
+++ b/src/KivyDesigner.kv
@@ -4,7 +4,7 @@
 BoxLayout:
     orientation: 'vertical'
     # This BoxLayout and child layouts create the menubar
-    BoxLayout: 
+    Toolbar: 
         size_hint: 1, None
         height: '24dp'
         canvas.before:
@@ -17,36 +17,9 @@ BoxLayout:
             size_hint: None, 1
             width: '30dp'
             source: ICON_PATH
-        Button:
-            id: btn_filemenu
+        FileToolbarGroup:
             size_hint: None, 1
-            # DropDown starts in opened state.
-            # Dismiss the dropdown when app starts
-            on_parent: file_dropdown.dismiss()
             width: '50dp'
-            text: 'File'
-            # Make the button transparent
-            background_color: 0,0,0,0
-            on_press: 
-                # Enable the color when button is pressed
-                self.background_color = 1,1,1,1
-                file_dropdown.open(self)
-            on_release:
-                self.background_color = 0,0,0,0
-            DropDown:
-                id: file_dropdown
-                # Allow the dropdown items to be wider than the parent
-                auto_width: False
-                Button:
-                    text: 'Open File'
-                    size_hint_y: None
-                    height: '24dp'
-                    on_release: file_dropdown.select('Open File')
-                Button: 
-                    text: 'Open Folder'
-                    size_hint_y: None
-                    height: '24dp'
-                    on_release: file_dropdown.select('Open Folder')
     BoxLayout: 
         # The main application including everything except toolbar
         BoxLayout:

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -1,15 +1,9 @@
 from kivy.properties import ObjectProperty, StringProperty
 from kivy.uix.boxlayout import BoxLayout
-from kivy.uix.textinput import TextInput
+from kivy.uix.codeinput import CodeInput
 from kivy.uix.label import Label
 from kivy.clock import Clock
 from kivy.lang import Builder
-
-class KivyEditor(TextInput):
-    # Note: I can use extras\highlight.py to syntax highlight the editor text!!
-    # Actualy codeinput.py provides this 'out of the box' functionality 
-    def __init__(self):
-        super().__init__()
 
 class KivyVisualizer(BoxLayout):
     # kivy's parser.py has a 'proxyapp'. Can I use this approach instead of choosing to insert the root widget?
@@ -17,7 +11,7 @@ class KivyVisualizer(BoxLayout):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.editor = KivyEditor()
+        self.editor = CodeInput(do_wrap=False)
         self.visualizer = BoxLayout()
         self.editor.bind(text=self.handle_kv_change)
         self.add_widget(self.editor)

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -25,7 +25,8 @@ class KivyVisualizer(BoxLayout):
         except Exception as e: 
             new_app = Label(text=str(e))
 
-        self.visualizer.add_widget(new_app)
+        if new_app:
+            self.visualizer.add_widget(new_app)
 
     def open_file(self, instance, new_filepath, new_filetxt):
         self.editor.text = new_filetxt

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -6,11 +6,14 @@ from kivy.clock import Clock
 from kivy.lang import Builder
 
 class KivyEditor(TextInput):
-    
+    # Note: I can use extras\highlight.py to syntax highlight the editor text!!
+    # Actualy codeinput.py provides this 'out of the box' functionality 
     def __init__(self):
         super().__init__()
 
 class KivyVisualizer(BoxLayout):
+    # kivy's parser.py has a 'proxyapp'. Can I use this approach instead of choosing to insert the root widget?
+    # There is also a 'Sandbox' widget that does the type of error catching we need...
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -1,0 +1,34 @@
+from kivy.properties import ObjectProperty, StringProperty
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.textinput import TextInput
+from kivy.uix.label import Label
+from kivy.clock import Clock
+from kivy.lang import Builder
+
+class KivyEditor(TextInput):
+    
+    def __init__(self):
+        super().__init__()
+
+class KivyVisualizer(BoxLayout):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.editor = KivyEditor()
+        self.visualizer = BoxLayout()
+        self.editor.bind(text=self.handle_kv_change)
+        self.add_widget(self.editor)
+        self.add_widget(self.visualizer)
+
+    def handle_kv_change(self, instance, value):
+        self.visualizer.clear_widgets()
+        
+        if not value: 
+            return 
+
+        try:
+            new_app = Builder.load_string(value)
+        except Exception as e: 
+            new_app = Label(text=str(e))
+
+        self.visualizer.add_widget(new_app)

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -35,3 +35,6 @@ class KivyVisualizer(BoxLayout):
             new_app = Label(text=str(e))
 
         self.visualizer.add_widget(new_app)
+
+    def open_file(self, instance, new_filepath, new_filetxt):
+        self.editor.text = new_filetxt

--- a/src/kivyvisualizer.py
+++ b/src/kivyvisualizer.py
@@ -6,9 +6,6 @@ from kivy.clock import Clock
 from kivy.lang import Builder
 
 class KivyVisualizer(BoxLayout):
-    # kivy's parser.py has a 'proxyapp'. Can I use this approach instead of choosing to insert the root widget?
-    # There is also a 'Sandbox' widget that does the type of error catching we need...
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.editor = CodeInput(do_wrap=False)

--- a/src/main.py
+++ b/src/main.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from kivy.app import App
 from kivy.lang import Builder
 from kivy.clock import Clock
+from kivy.factory import Factory 
 
 SRC_DIRECTORY = Path(os.path.dirname(__file__))
 DATA_FOLDER = os.path.join(SRC_DIRECTORY.parent, 'data') 
@@ -12,7 +13,6 @@ class KivyDesignerApp(App):
     def build(self):
         self.title = 'Kivy Designer'
         root_widget = Builder.load_file(os.path.join(SRC_DIRECTORY, 'KivyDesigner.kv'))
-        Clock.schedule_once(self.insert_visualizer, 1)
         return root_widget
 
     def on_stop(self):
@@ -20,15 +20,7 @@ class KivyDesignerApp(App):
         '''
         pass
 
-    def insert_visualizer(self, *args):
-        '''
-        Insert a test widget within the visualizer's layout
-
-        The production version will pass a path option that coincides with the 
-        editor file. 
-        '''
-        visualizer = Builder.load_file(os.path.join(SRC_DIRECTORY, 'Visualizer.kv'))
-        self.root.ids.visualizer_widget.add_widget(visualizer)
+Factory.register('KivyVisualizer', module='kivyvisualizer')
 
 if __name__ == '__main__':
     KivyDesignerApp().run()

--- a/src/main.py
+++ b/src/main.py
@@ -21,6 +21,8 @@ class KivyDesignerApp(App):
         pass
 
 Factory.register('KivyVisualizer', module='kivyvisualizer')
+Factory.register('Toolbar', module='toolbar')
+Factory.register('FileToolbarGroup', module='toolbar')
 
 if __name__ == '__main__':
     KivyDesignerApp().run()

--- a/src/main.py
+++ b/src/main.py
@@ -11,9 +11,7 @@ DATA_FOLDER = os.path.join(SRC_DIRECTORY.parent, 'data')
 ICON_PATH = os.path.join(DATA_FOLDER, 'kivy-icon-48.png')
 
 class RootWidget(BoxLayout):
-    def change_filename(self, instance, filename):
-        # update the toolbar's label to include this new filename
-        pass
+    pass
 
 class KivyDesignerApp(App):
     def build(self):

--- a/src/main.py
+++ b/src/main.py
@@ -4,10 +4,16 @@ from kivy.app import App
 from kivy.lang import Builder
 from kivy.clock import Clock
 from kivy.factory import Factory 
+from kivy.uix.boxlayout import BoxLayout
 
 SRC_DIRECTORY = Path(os.path.dirname(__file__))
 DATA_FOLDER = os.path.join(SRC_DIRECTORY.parent, 'data') 
 ICON_PATH = os.path.join(DATA_FOLDER, 'kivy-icon-48.png')
+
+class RootWidget(BoxLayout):
+    def change_filename(self, instance, filename):
+        # update the toolbar's label to include this new filename
+        pass
 
 class KivyDesignerApp(App):
     def build(self):
@@ -20,6 +26,7 @@ class KivyDesignerApp(App):
         '''
         pass
 
+Factory.register('RootWidget', module='main')
 Factory.register('KivyVisualizer', module='kivyvisualizer')
 Factory.register('Toolbar', module='toolbar')
 Factory.register('FileToolbarGroup', module='toolbar')

--- a/src/main.py
+++ b/src/main.py
@@ -1,17 +1,34 @@
 import os
 from pathlib import Path
 from kivy.app import App
-from kivy.uix.boxlayout import BoxLayout
+from kivy.lang import Builder
+from kivy.clock import Clock
 
-DATA_FOLDER = os.path.join(Path(os.path.dirname(__file__)).parent, 'data') 
+SRC_DIRECTORY = Path(os.path.dirname(__file__))
+DATA_FOLDER = os.path.join(SRC_DIRECTORY.parent, 'data') 
 ICON_PATH = os.path.join(DATA_FOLDER, 'kivy-icon-48.png')
-
-class KivyDesignerRoot(BoxLayout):
-    pass
 
 class KivyDesignerApp(App):
     def build(self):
-        return KivyDesignerRoot()
+        self.title = 'Kivy Designer'
+        root_widget = Builder.load_file(os.path.join(SRC_DIRECTORY, 'KivyDesigner.kv'))
+        Clock.schedule_once(self.insert_visualizer, 1)
+        return root_widget
+
+    def on_stop(self):
+        '''Clean up application resources, such as Watchdog observer.
+        '''
+        pass
+
+    def insert_visualizer(self, *args):
+        '''
+        Insert a test widget within the visualizer's layout
+
+        The production version will pass a path option that coincides with the 
+        editor file. 
+        '''
+        visualizer = Builder.load_file(os.path.join(SRC_DIRECTORY, 'Visualizer.kv'))
+        self.root.ids.visualizer_widget.add_widget(visualizer)
 
 if __name__ == '__main__':
     KivyDesignerApp().run()

--- a/src/toolbar.py
+++ b/src/toolbar.py
@@ -1,7 +1,7 @@
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.dropdown import DropDown
 from kivy.uix.button import Button
-from kivy.uix.filechooser import FileChooser
+from plyer import filechooser
 
 class Toolbar(BoxLayout):
     pass
@@ -49,7 +49,15 @@ class FileToolbarGroup(Button):
     def _open_file(self):
         # User filechooser to select file
         # pass filename to dispatch function
-        self.dispatch("on_open_file", "filename")
+        # Note: This will block the main thread, but that is
+        # fine. We don't need to do anything until file is selected
+        file_path = filechooser.open_file(title='Open kv file to visualize', 
+          filters = [['kv file (*kv)', '*kv'], ['all', '*']])
+        if file_path:
+            # Default to first selection in the event of a multiselect
+            with open(file_path[0], 'r', encoding='utf8') as reader:
+                file_contents = reader.read()
+                self.dispatch("on_open_file", file_path[0], file_contents)
 
     def _new_file(self):
         # use filechooser to set a new file name
@@ -59,5 +67,5 @@ class FileToolbarGroup(Button):
     def _open_folder(self):
         pass
 
-    def on_open_file(self, opened_filename):
+    def on_open_file(self, opened_filename, opened_filetxt):
         pass

--- a/src/toolbar.py
+++ b/src/toolbar.py
@@ -1,0 +1,40 @@
+from kivy.uix.boxlayout import BoxLayout
+from kivy.uix.dropdown import DropDown
+from kivy.uix.button import Button
+
+class Toolbar(BoxLayout):
+    pass
+
+class FileToolbarGroup(Button):
+
+    def __init__(self, **kwargs):
+        super().__init__(text='File', background_color=(1,1,1,0), **kwargs)
+        # Disable auto_width to allow the children buttons to 
+        # be wider than the action group root button
+        self._dropdown = DropDown(auto_width=False)
+        self._dropdown.bind(on_select=self.on_dropdown_select)
+        self._add_button('Open File', self.on_open_file)
+        self._add_button('Open Folder', self.on_open_folder)
+    
+    def _add_button(self, caption, btn_handler):
+        btn = Button(text=caption, size_hint_y=None, height=24)
+        # Bind the button event to dropdown.select() to properly dismiss
+        # the dropdown menu. Pass the specific handler through the dropdown
+        # selection. on_dropdown_select will invoke the handler. 
+        btn.bind(on_release=lambda btn: self._dropdown.select(btn_handler))
+        self._dropdown.add_widget(btn)
+
+    def on_dropdown_select(self, instance, selection_handler):
+        if(not callable(selection_handler)):
+            raise ValueError('FileToolbar dropdown selections should pass their OnPress event handler.')
+        selection_handler()
+
+    def on_press(self, *args):
+        super().on_press(*args)
+        self._dropdown.open(self)
+
+    def on_open_file(self, *args):
+        pass
+
+    def on_open_folder(self, *args):
+        pass

--- a/src/toolbar.py
+++ b/src/toolbar.py
@@ -1,20 +1,33 @@
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.dropdown import DropDown
 from kivy.uix.button import Button
+from kivy.uix.filechooser import FileChooser
 
 class Toolbar(BoxLayout):
     pass
 
 class FileToolbarGroup(Button):
+    '''FileToolbarGroup class. Custom Actionbar group for managing 
+    file operations from the main application toolbar. 
 
+    :Events:
+        `on_open_file`
+            Fired when a file is opened by the toolbar, either by creating
+            a new file or selecting an existing file.
+    '''
+
+    __events__ = ['on_open_file']
+
+    
     def __init__(self, **kwargs):
         super().__init__(text='File', background_color=(1,1,1,0), **kwargs)
         # Disable auto_width to allow the children buttons to 
         # be wider than the action group root button
         self._dropdown = DropDown(auto_width=False)
-        self._dropdown.bind(on_select=self.on_dropdown_select)
-        self._add_button('Open File', self.on_open_file)
-        self._add_button('Open Folder', self.on_open_folder)
+        self._dropdown.bind(on_select=self._dropdown_select)
+        self._add_button('Open File', self._open_file)
+        self._add_button('Open Folder', self._open_folder)
+        self._add_button('New File', self._new_file)
     
     def _add_button(self, caption, btn_handler):
         btn = Button(text=caption, size_hint_y=None, height=24)
@@ -24,7 +37,7 @@ class FileToolbarGroup(Button):
         btn.bind(on_release=lambda btn: self._dropdown.select(btn_handler))
         self._dropdown.add_widget(btn)
 
-    def on_dropdown_select(self, instance, selection_handler):
+    def _dropdown_select(self, instance, selection_handler):
         if(not callable(selection_handler)):
             raise ValueError('FileToolbar dropdown selections should pass their OnPress event handler.')
         selection_handler()
@@ -33,8 +46,18 @@ class FileToolbarGroup(Button):
         super().on_press(*args)
         self._dropdown.open(self)
 
-    def on_open_file(self, *args):
+    def _open_file(self):
+        # User filechooser to select file
+        # pass filename to dispatch function
+        self.dispatch("on_open_file", "filename")
+
+    def _new_file(self):
+        # use filechooser to set a new file name
+        # pass filename to dispatch
+        self.dispatch("on_open_file", "filename")
+
+    def _open_folder(self):
         pass
 
-    def on_open_folder(self, *args):
+    def on_open_file(self, opened_filename):
         pass


### PR DESCRIPTION
Added the ability to open and visualize a kv app. The application must be fully defined in kvlang at the current moment. We will add the ability to register custom widgets in a future PR.

The visualization approach is very simple. We build the root widget using the kivy builder, and we add the widget to a BoxLayout within our application. This approach works for the simplest of cases, but is not broadly applicable to all applications. 

We'll need a more advanced design if we hope to allow users to visualize their app with custom kivy configurations, since the root widget is being build within the visualization app. I believe the only way to do something like this would be to run a separate instance of kivy. More research is required to figure out how to achieve this (without using a hack!)

This PR also updates the title bar to allow file selection, and move the toolbar logic into its own module, `toolbar.py`. Here is a picture of the current app. 

![image](https://user-images.githubusercontent.com/22138019/193420697-e7c3ad3c-1198-4ce9-baff-e394bcf3ec7d.png)
 